### PR TITLE
Calling correct radial function

### DIFF
--- a/src/_spimage_prtf.py
+++ b/src/_spimage_prtf.py
@@ -102,7 +102,7 @@ def prtf(images_rs,supports,translate=True,enantio=True,full_out=False):
     out["prtf"] = prtf
     out["super_image"] = avg_img
     if full_out:
-        out["prtf_r"] = spimage.radial_mean(prtf,shell_thickness=1.0) 
+        out["prtf_r"] = spimage.radial(prtf,f=numpy.mean,shell_thickness=1.0) 
         out["super_mask"] = avg_sup 
         out["images"] = images_rs_super
         out["masks"] = masks_rs_super


### PR DESCRIPTION
The correct radial function is called now when radially-integrating the 3D PRTF. 
The old radial_mean function does not exist anymore. 
The default reduction operation, `np.mean`, is explicitly written down. 

